### PR TITLE
fix: remove use of no longer available components fields

### DIFF
--- a/src/search/UIPoweredInputText.ts
+++ b/src/search/UIPoweredInputText.ts
@@ -6,9 +6,6 @@ import { InitialUIProperties, UIBase } from './commons/UIBase'
 export class UIPoweredInputText extends UIBase<UIInputText> {
   private static readonly DEFAULT_WAIT_TIME = 650
   private readonly placeholder: string
-  private readonly placeholderColor: Color4
-  private readonly background: Color4
-  private readonly color: Color4
   private inputValue: string = ''
   private isInputFocused: boolean = false
 
@@ -16,7 +13,6 @@ export class UIPoweredInputText extends UIBase<UIInputText> {
     super(new UIInputText(parent), {
       ...initialProperties,
       placeholder: initialProperties?.placeholder ?? initialProperties?.value,
-      placeholderColor: initialProperties?.placeholderColor ?? initialProperties?.color,
       onFocus: new OnFocus(() => {
         this.isInputFocused = true
         initialProperties?.onFocus?.()
@@ -33,11 +29,8 @@ export class UIPoweredInputText extends UIBase<UIInputText> {
       onChanged: new OnChanged(({ value }) => {
         if (this.shape.visible) {
           this.inputValue = value
-          if (value === this.placeholder) {
-            this.shape.placeholderColor = this.placeholderColor
-          } else {
+          if (value !== this.placeholder) {
             if (value === '') {
-              this.shape.placeholderColor = this.color
               this.shape.placeholder = ''
             }
             if (this.isInputFocused || value === '') {
@@ -66,8 +59,6 @@ export class UIPoweredInputText extends UIBase<UIInputText> {
       })
     })
     this.placeholder = this.shape.placeholder
-    this.color = this.shape.color
-    this.placeholderColor = this.shape.placeholderColor
     this.inputValue = initialProperties?.value ?? initialProperties?.placeholder ?? ''
     this.isInputFocused = false
   }

--- a/src/search/UISearchPrompt.ts
+++ b/src/search/UISearchPrompt.ts
@@ -40,7 +40,7 @@ export class UISearchPrompt extends UIBase<UIContainerRect> {
   private readonly insideContainer: UIContainerRect
   private readonly errorMessage: UIText
   private readonly uiOptions: UISearchPromptOption[] = []
-  private options: {[ id: string ]: SearchPromptOption} = {}
+  private options: { [id: string]: SearchPromptOption } = {}
   private defaultOptions: string[] | undefined
 
   constructor(
@@ -79,10 +79,8 @@ export class UISearchPrompt extends UIBase<UIContainerRect> {
       width: '92%',
       fontSize: this.config.search.fontSize,
       placeholder: this.config.search.placeholder.defaultText,
-      placeholderColor: this.config.search.placeholder.textColor,
       color: this.config.search.textColor,
       focusedBackground: Color4.Clear(),
-      background: Color4.Clear(),
       height: this.config.initialHeight * 0.95,
       onBlur: () => this.close(),
       onTextSubmit: () => {
@@ -177,7 +175,7 @@ export class UISearchPrompt extends UIBase<UIContainerRect> {
       curr.searchBy = curr.searchBy ?? (typeof curr.visualText === 'string' ? curr.visualText : ('text' in curr.visualText ? curr.visualText.text : curr.visualText.topLeft))
       acc[curr.id] = curr;
       return acc
-    }, { } as {[ id: string ]: SearchPromptOption});
+    }, {} as { [id: string]: SearchPromptOption });
     if (dropdownDefaults) {
       this.setDropdownDefaults(dropdownDefaults)
     } else {


### PR DESCRIPTION
`UIInputText` fields: `placeholderColor` and `background` were removed from ecs here: https://github.com/decentraland/js-sdk-toolchain/pull/56 since there were never implemented on the renderer.
so it's currently breaking the build of the library