### PR TITLE
Add onClose callback to CustomPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,12 +331,13 @@ let prompt = new ui.CustomPrompt(ui.PromptStyles.DARKSLANTED)
 
 <img src="screenshots/customPrompt1.png" width="400">
 
-When instancing a new loading icon, you can pass the following parameters:
+When instancing a new CustomPrompt, you can pass the following parameters:
 
 - `style`: Pick from a few predefined options, some of them using the dark theme, others the light theme. You can also provide a string with a path to a custom image to use as a background instead.
 - `width`: Background width on screen in pixels. The default size depends on the theme used.
 - `height`: Background height on screen in pixels. The default size depends on the theme used.
 - `startHidden`: If true, image starts invisible to load in the background till calling the `show()` function of the prompt object.
+- `onClose`: If provided, a callback function that fires when the prompt is closed via the (X) button.
 
 > Note: Stretching the background images away from their default values may lead to blurry corners.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3025,15 +3025,16 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/marked-terminal": {
@@ -8829,6 +8830,18 @@
         "node": ">=10.13"
       }
     },
+    "node_modules/semantic-release/node_modules/marked": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 8.16.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -12383,10 +12396,11 @@
       }
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
-      "dev": true
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
+      "dev": true,
+      "peer": true
     },
     "marked-terminal": {
       "version": "3.3.0",
@@ -16820,6 +16834,14 @@
         "semver-diff": "^3.1.1",
         "signale": "^1.2.1",
         "yargs": "^15.0.1"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+          "dev": true
+        }
       }
     },
     "semver": {

--- a/src/prompts/customPrompt/index.ts
+++ b/src/prompts/customPrompt/index.ts
@@ -36,7 +36,8 @@ export class CustomPrompt extends Entity {
     style?: PromptStyles | string,
     width?: number,
     height?: number,
-    startHidden?: boolean
+    startHidden?: boolean,
+    onClose?: () => void
   ) {
     super()
 
@@ -115,6 +116,7 @@ export class CustomPrompt extends Entity {
 
     this.closeIcon.onClick = new OnClick(() => {
       this.hide()
+      onClose()
     })
 
     if (startHidden) {

--- a/src/prompts/customPrompt/index.ts
+++ b/src/prompts/customPrompt/index.ts
@@ -116,7 +116,8 @@ export class CustomPrompt extends Entity {
 
     this.closeIcon.onClick = new OnClick(() => {
       this.hide()
-      onClose()
+      //Optional onClose callback
+      onClose?.()
     })
 
     if (startHidden) {

--- a/src/prompts/customPrompt/index.ts
+++ b/src/prompts/customPrompt/index.ts
@@ -115,9 +115,9 @@ export class CustomPrompt extends Entity {
     this.closeIcon.source = this.texture
 
     this.closeIcon.onClick = new OnClick(() => {
-      this.hide()
       //Optional onClose callback
       onClose?.()
+      this.hide()
     })
 
     if (startHidden) {


### PR DESCRIPTION
Support an optional onClose callback function being passed to the CustomPrompt constructor which fires when the (X) button is clicked. The onClose callback is added to end of constructor so there will be no breaking changes. Addresses issue #10 